### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/neocities/ruby-multihash.svg)](https://travis-ci.org/neocities/ruby-multihash)
 
-A [Multihash](https://github.com/jbenet/multihash) implementation for ruby.
+A [Multihash](https://github.com/multiformats/multihash) implementation for ruby.
 
 A multihash is a digest with an embedded hash function code (and length) (['cause you never know](https://twitter.com/matthew_d_green/status/597409850381836288)). It was developed primarily for use with [IPFS](https://github.com/ipfs/ipfs), but is not specific to it.
 
@@ -64,4 +64,4 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/neocit
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein
### GitHub Corrected URLs

| Was | Now |
| --- | --- |
| https://github.com/jbenet/multihash | https://github.com/multiformats/multihash |
### HTTPS Corrected URLs

| Was | Now |
| --- | --- |
| http://opensource.org/licenses/MIT | https://opensource.org/licenses/MIT |
