### PR TITLE
Adds support for md5 hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ out = Multihashes.decode multihash_binary_string
 Hash function names (latest is [here](https://github.com/multiformats/multihash/blob/master/hashtable.csv))
 
     code name
+    0xd5 md5
     0x11 sha1
     0x12 sha2-256
     0x13 sha2-512

--- a/lib/multihashes.rb
+++ b/lib/multihashes.rb
@@ -6,6 +6,7 @@ module Multihashes
 
   # https://github.com/jbenet/multihash
   TABLE = {
+    0xd5 => 'md5',
     0x11 => 'sha1',
     0x12 => 'sha2-256',
     0x13 => 'sha2-512',


### PR DESCRIPTION
Adds md5 support using the code and name from https://github.com/multiformats/multihash/blob/master/hashtable.csv

I know the md5 cryptographic hash is obsolete as discussed in the [disclaimer](https://github.com/multiformats/multihash), but this functionality would allow handling pre-existing legacy hashes.